### PR TITLE
Add support for local openai-whisper in ts command

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,14 @@ options:
 
 'ts' is a command that uses the OpenAI Whisper API to transcribe audio files. Due to the context window, this tool uses pydub to split the files into 10 minute segments. for more information on pydub, please refer https://github.com/jiaaro/pydub
 
+While OpenAI's API Whisper is more accurate than the local openai-whisper, it does come with a cost. So, if your local PC has enough resources, you can use the local openai-whisper for transcription to save money. This allows you to choose between the accuracy of the API and the cost-effectiveness of local processing based on your needs and available resources.
+
+To use the local openai-whisper, run the following command to add the package:
+
+```bash
+pipx inject fabric openai-whisper
+```
+
 ### Installation
 
 ```bash

--- a/installer/client/cli/ts.py
+++ b/installer/client/cli/ts.py
@@ -3,6 +3,12 @@ from pydub import AudioSegment
 from openai import OpenAI
 import os
 import argparse
+try:
+    import whisper as local_whisper
+    import torch
+    use_local_whisper = True
+except ImportError:
+    use_local_whisper = False
 
 
 class Whisper:
@@ -68,7 +74,7 @@ class Whisper:
         except Exception as e:
             print(f"Error: {e}")
 
-    def process_file(self, audio_file):
+    def process_file(self, audio_file, language="en", localOpenaiWhisper=False):
         """        Transcribe an audio file and print the transcript.
 
         Args:
@@ -78,32 +84,60 @@ class Whisper:
             None
         """
 
-        try:
-            # if audio_file.startswith("http"):
-            #     response = requests.get(audio_file)
-            #     response.raise_for_status()
-            #     with tempfile.NamedTemporaryFile(delete=False) as f:
-            #         f.write(response.content)
-            #         audio_file = f.name
+        if localOpenaiWhisper:
+            try:
+                if not use_local_whisper:
+                    raise ImportError("Local `openai-whisper` model not found. Please install it using `pipx inject fabric openai-whisper`.")
 
-            segments = self.split_audio(audio_file)
-            for i, segment in enumerate(segments):
-                segment_file_path = f"segment_{i}.mp3"
-                segment.export(segment_file_path, format="mp3")
-                self.process_segment(segment_file_path)
-            print(' '.join(self.whole_response))
+                if audio_file.endswith(".mp3"):
+                    # switch to wav format
+                    audio = AudioSegment.from_mp3(audio_file)
+                    audio_file = audio_file.replace(".mp3", ".wav")
+                    audio.export(audio_file, format="wav")
+                model = local_whisper.load_model(
+                    "base",
+                    device="cuda" if torch.cuda.is_available() else "cpu"
+                )
+                result = model.transcribe(
+                    audio_file,
+                    language=language,
+                    # set False to display progress bar for debugging
+                    # verbose=False
+                )
+                print(result["text"])
 
-        except Exception as e:
-            print(f"Error: {e}")
+            except Exception as e:
+                print(f"Error: {e}")
+
+        else:
+            try:
+                # if audio_file.startswith("http"):
+                #     response = requests.get(audio_file)
+                #     response.raise_for_status()
+                #     with tempfile.NamedTemporaryFile(delete=False) as f:
+                #         f.write(response.content)
+                #         audio_file = f.name
+
+                segments = self.split_audio(audio_file)
+                for i, segment in enumerate(segments):
+                    segment_file_path = f"segment_{i}.mp3"
+                    segment.export(segment_file_path, format="mp3")
+                    self.process_segment(segment_file_path)
+                print(' '.join(self.whole_response))
+
+            except Exception as e:
+                print(f"Error: {e}")
 
 
 def main():
     parser = argparse.ArgumentParser(description="Transcribe an audio file.")
     parser.add_argument(
         "audio_file", help="The path to the audio file to be transcribed.")
+    parser.add_argument('--lang', default='en', help='Language for the transcript (default: English). This is only used for the local model. (default: en)')
+    parser.add_argument('--localOpenaiWhisper', action='store_true', help='Use Local `openai-whisper` model for transcription. (default: False)')
     args = parser.parse_args()
     whisper = Whisper()
-    whisper.process_file(args.audio_file)
+    whisper.process_file(args.audio_file, args.lang, args.localOpenaiWhisper)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Updated `README.md` to include instructions for using local openai-whisper.
- Added error handling to `ts.py` for cases where `import whisper` fails.
- Modified `ts.py` to support the use of the local openai-whisper model.
- Added new command-line arguments to `ts.py` for specifying language and using the local openai-whisper model.

To use the local openai-whisper, run:
pipx inject fabric openai-whisper

This update allows users to choose between the accuracy of the OpenAI API and the cost-effectiveness of local processing.

## What this Pull Request (PR) does
Please briefly describe what this PR does.

## Related issues
Please reference any open issues this PR relates to in here.
If it closes an issue, type `closes #[ISSUE_NUMBER]`.

## Screenshots
Provide any screenshots you may find relevant to facilitate us understanding your PR.
